### PR TITLE
Android 17, Background audio hardening

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,12 +11,12 @@ val versionPatch = 2
 val versionBuild = 0
 
 android {
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         applicationId = "fr.smarquis.sleeptimer"
         namespace = "fr.smarquis.sleeptimer"
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 37
         versionCode = versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
         versionName = "$versionMajor.$versionMinor.$versionPatch"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:minSdkVersion="37" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" android:minSdkVersion="37" tools:ignore="ForegroundServicesPolicy" />
 
     <application
         android:allowBackup="false"
@@ -28,7 +30,7 @@
                 android:name="android.service.quicksettings.TOGGLEABLE_TILE"
                 android:value="true" />
         </service>
-        <service android:name=".SleepAudioService" />
+        <service android:name=".SleepAudioService" android:foregroundServiceType="shortService" />
         <receiver android:name=".SleepActionReceiver" android:exported="false" />
     </application>
 

--- a/app/src/main/java/fr/smarquis/sleeptimer/Context.ext.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/Context.ext.kt
@@ -1,0 +1,11 @@
+package fr.smarquis.sleeptimer
+
+import android.app.AlarmManager
+import android.app.NotificationManager
+import android.content.Context
+import android.media.AudioManager
+
+
+fun Context.alarmManager(): AlarmManager = getSystemService(AlarmManager::class.java)
+fun Context.audioManager(): AudioManager = getSystemService(AudioManager::class.java)
+fun Context.notificationManager(): NotificationManager = getSystemService(NotificationManager::class.java)

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepAudioService.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepAudioService.kt
@@ -1,11 +1,13 @@
 package fr.smarquis.sleeptimer
 
+import android.app.Notification
+import android.app.Notification.CATEGORY_SERVICE
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.content.Context
 import android.content.Intent
-import android.media.AudioManager
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
 import android.media.AudioManager.ADJUST_LOWER
 import android.media.AudioManager.STREAM_MUSIC
 import android.view.KeyEvent
@@ -13,7 +15,9 @@ import android.view.KeyEvent.ACTION_DOWN
 import android.view.KeyEvent.ACTION_UP
 import android.view.KeyEvent.KEYCODE_MEDIA_PAUSE
 import fr.smarquis.sleeptimer.SleepTileService.Companion.requestTileUpdate
+import fr.smarquis.sleeptimer.SleepTimer.REQUIRES_FOREGROUND_SERVICE
 import java.util.concurrent.TimeUnit.SECONDS
+
 
 @Suppress("DEPRECATION")
 class SleepAudioService : android.app.IntentService("SleepAudioService") {
@@ -23,16 +27,22 @@ class SleepAudioService : android.app.IntentService("SleepAudioService") {
         private val RESTORE_VOLUME_MILLIS = SECONDS.toMillis(2)
         private const val VOLUME_EXTRA_KEY = "extras:volume"
 
-        private fun Context.audioManager() = getSystemService(AudioManager::class.java)
-
         private fun intent(context: Context) = Intent(context, SleepAudioService::class.java)
-            .putExtra(VOLUME_EXTRA_KEY, context.audioManager()?.getStreamVolume(STREAM_MUSIC))
+            .putExtra(VOLUME_EXTRA_KEY, context.audioManager().getStreamVolume(STREAM_MUSIC))
 
-        fun pendingIntent(context: Context): PendingIntent? = PendingIntent.getService(context, 0, intent(context), FLAG_IMMUTABLE or FLAG_UPDATE_CURRENT)
+        fun pendingIntent(context: Context): PendingIntent =
+            if (REQUIRES_FOREGROUND_SERVICE) PendingIntent.getForegroundService(context, 0, intent(context), FLAG_IMMUTABLE or FLAG_UPDATE_CURRENT)
+            else PendingIntent.getService(context, 0, intent(context), FLAG_IMMUTABLE or FLAG_UPDATE_CURRENT)
     }
 
     @Deprecated("Deprecated in Java")
-    override fun onHandleIntent(intent: Intent?) = audioManager()?.run {
+    override fun onHandleIntent(intent: Intent?) {
+        if (REQUIRES_FOREGROUND_SERVICE) startForeground(R.id.notification_service_id, notification(), FOREGROUND_SERVICE_TYPE_SHORT_SERVICE)
+        sleep(intent)
+        if (REQUIRES_FOREGROUND_SERVICE) stopForeground(STOP_FOREGROUND_REMOVE)
+    }
+
+    private fun sleep(intent: Intent?) = with(audioManager()) {
         // compute volume to restore
         val currentVolume = getStreamVolume(STREAM_MUSIC)
         val volumeToRestore = intent
@@ -55,6 +65,16 @@ class SleepAudioService : android.app.IntentService("SleepAudioService") {
 
         // update tile
         requestTileUpdate()
-    } ?: Unit
+    }
+
+    /**
+     * Foreground notification to display during [sleep].
+     */
+    private fun notification() = Notification.Builder(this, getString(R.string.notification_channel_id))
+        .setCategory(CATEGORY_SERVICE)
+        .setSmallIcon(R.drawable.ic_tile)
+        .setProgress(100, 50, true)
+        .setOngoing(true)
+        .build()
 
 }

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepNotification.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepNotification.kt
@@ -1,19 +1,21 @@
 package fr.smarquis.sleeptimer
 
+import android.app.AlarmManager.RTC_WAKEUP
 import android.app.Notification
 import android.app.Notification.CATEGORY_EVENT
 import android.app.Notification.VISIBILITY_PUBLIC
 import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.NotificationManager.IMPORTANCE_LOW
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Icon
+import android.widget.Toast
 import fr.smarquis.sleeptimer.SleepNotification.Action.CANCEL
 import fr.smarquis.sleeptimer.SleepNotification.Action.DECREMENT
 import fr.smarquis.sleeptimer.SleepNotification.Action.INCREMENT
+import fr.smarquis.sleeptimer.SleepTimer.REQUIRES_FOREGROUND_SERVICE
 import java.lang.System.currentTimeMillis
 import java.text.DateFormat
 import java.text.DateFormat.SHORT
@@ -54,9 +56,7 @@ object SleepNotification {
         abstract fun title(context: Context): CharSequence?
     }
 
-    fun Context.notificationManager(): NotificationManager? = getSystemService(NotificationManager::class.java)
-
-    fun Context.find() = notificationManager()?.activeNotifications?.firstOrNull { it.id == R.id.notification_id }?.notification
+    fun Context.find() = notificationManager().activeNotifications?.firstOrNull { it.id == R.id.notification_id }?.notification
 
     fun Context.handle(intent: Intent?) = when (Action.parse(intent?.action)) {
         INCREMENT -> update(TIMEOUT_INCREMENT_MILLIS)
@@ -70,7 +70,7 @@ object SleepNotification {
      */
     fun Context.toggle(): Boolean = if (find() == null) { show(); true } else { cancel(); false }
 
-    private fun Context.cancel() = notificationManager()?.cancel(R.id.notification_id) ?: Unit
+    private fun Context.cancel() = notificationManager().cancel(R.id.notification_id)
 
     private fun Context.update(delta: Long) = find()?.let { existing ->
         val remaining = existing.`when` - currentTimeMillis()
@@ -90,13 +90,18 @@ object SleepNotification {
             .setShowWhen(true).setWhen(eta)
             .setUsesChronometer(true).setChronometerCountDown(true)
             .setTimeoutAfter(timeout)
-            .setDeleteIntent(existing?.deleteIntent ?: SleepAudioService.pendingIntent(this))
+            .apply { if (!REQUIRES_FOREGROUND_SERVICE) setDeleteIntent(existing?.deleteIntent ?: SleepAudioService.pendingIntent(this@show)) }
             .addAction(INCREMENT.action(this).build())
             .addAction(DECREMENT.action(this, cancel = timeout <= TIMEOUT_DECREMENT_MILLIS).build())
             .addAction(CANCEL.action(this).build())
             .build()
         createNotificationChannel()
-        notificationManager()?.notify(R.id.notification_id, notification)
+        notificationManager().notify(R.id.notification_id, notification)
+
+        if (REQUIRES_FOREGROUND_SERVICE) {
+            if (alarmManager().canScheduleExactAlarms().not()) Toast.makeText(this, R.string.toast_alarm_permission, Toast.LENGTH_LONG).show()
+            else alarmManager().setExactAndAllowWhileIdle(RTC_WAKEUP, eta, SleepAudioService.pendingIntent(this@show))
+        }
     }
 
     private fun Context.createNotificationChannel() {
@@ -106,7 +111,7 @@ object SleepNotification {
             setBypassDnd(true)
             lockscreenVisibility = VISIBILITY_PUBLIC
         }
-        notificationManager()?.createNotificationChannel(channel)
+        notificationManager().createNotificationChannel(channel)
     }
 
 }

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepNotification.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepNotification.kt
@@ -28,6 +28,7 @@ object SleepNotification {
     private val TIMEOUT_INITIAL_MILLIS = MINUTES.toMillis(30)
     private val TIMEOUT_INCREMENT_MILLIS = MINUTES.toMillis(10)
     private val TIMEOUT_DECREMENT_MILLIS = MINUTES.toMillis(10)
+    private const val SLEEP_INTENT_EXTRA_KEY = "extras:SleepPendingIntent"
 
     private enum class Action(private val value: String) {
         CANCEL("fr.smarquis.sleeptimer.action.CANCEL") {
@@ -80,6 +81,12 @@ object SleepNotification {
     private fun Context.show(timeout: Long = TIMEOUT_INITIAL_MILLIS, existing: Notification? = null) {
         require(timeout > 0)
         val eta = currentTimeMillis() + timeout
+        // Keep track of the original PendingIntent inside the notification's extras because
+        // we can't rely on the Notification `deleteIntent` when `REQUIRES_FOREGROUND_SERVICE`
+        val sleepPendingIntent = when {
+            !REQUIRES_FOREGROUND_SERVICE -> existing?.deleteIntent
+            else -> existing?.extras?.getParcelable(SLEEP_INTENT_EXTRA_KEY, PendingIntent::class.java)
+        } ?: SleepAudioService.pendingIntent(this)
         val notification = Notification.Builder(this, getString(R.string.notification_channel_id))
             .setCategory(CATEGORY_EVENT)
             .setVisibility(VISIBILITY_PUBLIC)
@@ -90,7 +97,10 @@ object SleepNotification {
             .setShowWhen(true).setWhen(eta)
             .setUsesChronometer(true).setChronometerCountDown(true)
             .setTimeoutAfter(timeout)
-            .apply { if (!REQUIRES_FOREGROUND_SERVICE) setDeleteIntent(existing?.deleteIntent ?: SleepAudioService.pendingIntent(this@show)) }
+            .apply {
+                if (!REQUIRES_FOREGROUND_SERVICE) setDeleteIntent(sleepPendingIntent)
+                else extras.putParcelable(SLEEP_INTENT_EXTRA_KEY, sleepPendingIntent)
+            }
             .addAction(INCREMENT.action(this).build())
             .addAction(DECREMENT.action(this, cancel = timeout <= TIMEOUT_DECREMENT_MILLIS).build())
             .addAction(CANCEL.action(this).build())
@@ -100,7 +110,7 @@ object SleepNotification {
 
         if (REQUIRES_FOREGROUND_SERVICE) {
             if (alarmManager().canScheduleExactAlarms().not()) Toast.makeText(this, R.string.toast_alarm_permission, Toast.LENGTH_LONG).show()
-            else alarmManager().setExactAndAllowWhileIdle(RTC_WAKEUP, eta, SleepAudioService.pendingIntent(this@show))
+            else alarmManager().setExactAndAllowWhileIdle(RTC_WAKEUP, eta, sleepPendingIntent)
         }
     }
 

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
@@ -6,6 +6,8 @@ import android.app.PendingIntent.getActivity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.Q
 import android.os.Build.VERSION_CODES.TIRAMISU
@@ -13,9 +15,10 @@ import android.provider.Settings
 import android.service.quicksettings.Tile.STATE_ACTIVE
 import android.service.quicksettings.Tile.STATE_INACTIVE
 import android.service.quicksettings.TileService
+import android.widget.Toast
 import fr.smarquis.sleeptimer.SleepNotification.find
-import fr.smarquis.sleeptimer.SleepNotification.notificationManager
 import fr.smarquis.sleeptimer.SleepNotification.toggle
+import fr.smarquis.sleeptimer.SleepTimer.REQUIRES_FOREGROUND_SERVICE
 import java.text.DateFormat.SHORT
 import java.text.DateFormat.getTimeInstance
 import java.util.Date
@@ -28,9 +31,10 @@ class SleepTileService : TileService() {
 
     override fun onStartListening() = refreshTile()
 
-    override fun onClick() = when (notificationManager()?.areNotificationsEnabled()) {
-        true -> toggle().let(::refreshTile)
-        else -> requestNotificationsPermission()
+    override fun onClick() = when {
+        notificationManager().areNotificationsEnabled().not() -> requestNotificationsPermission()
+        REQUIRES_FOREGROUND_SERVICE && alarmManager().canScheduleExactAlarms().not() -> requestScheduleExactAlarmsPermission()
+        else -> toggle().let(::refreshTile)
     }
 
     /**
@@ -38,12 +42,13 @@ class SleepTileService : TileService() {
      */
     private fun refreshTile(hint: Boolean? = null) = qsTile?.run {
         val notification = find()
-        when  {
+        when {
             // The canceled notification might still be considered active by NotificationManager... so we use an extra hint
             notification == null || hint == false -> {
                 state = STATE_INACTIVE
                 if (SDK_INT >= Q) subtitle = resources.getText(R.string.tile_subtitle)
             }
+
             else -> {
                 state = STATE_ACTIVE
                 if (SDK_INT >= Q) subtitle = getTimeInstance(SHORT).format(Date(notification.`when`))
@@ -52,13 +57,21 @@ class SleepTileService : TileService() {
         updateTile()
     } ?: Unit
 
-    private fun requestNotificationsPermission() = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
-    }.let {
-        @SuppressLint("StartActivityAndCollapseDeprecated")
-        if (SDK_INT <= TIRAMISU) @Suppress("DEPRECATION") startActivityAndCollapse(it)
-        else startActivityAndCollapse(getActivity(this, 0, it, FLAG_IMMUTABLE))
+    private fun requestNotificationsPermission() {
+        Toast.makeText(this, R.string.toast_notification_permission, Toast.LENGTH_LONG).show()
+        startActivityAndCollapseCompat(Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS))
     }
 
+    private fun requestScheduleExactAlarmsPermission() {
+        Toast.makeText(this, R.string.toast_alarm_permission, Toast.LENGTH_LONG).show()
+        if (SDK_INT >= Build.VERSION_CODES.S) startActivityAndCollapseCompat(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+    }
+
+    private fun startActivityAndCollapseCompat(intent: Intent) {
+        intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
+        intent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        @SuppressLint("StartActivityAndCollapseDeprecated")
+        if (SDK_INT <= TIRAMISU) @Suppress("DEPRECATION") startActivityAndCollapse(intent)
+        else startActivityAndCollapse(getActivity(this, 0, intent, FLAG_IMMUTABLE))
+    }
 }

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
@@ -7,6 +7,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.Q
@@ -59,17 +60,16 @@ class SleepTileService : TileService() {
 
     private fun requestNotificationsPermission() {
         Toast.makeText(this, R.string.toast_notification_permission, Toast.LENGTH_LONG).show()
-        startActivityAndCollapseCompat(Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS))
+        startActivityAndCollapseCompat(Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).putExtra(Settings.EXTRA_APP_PACKAGE, packageName))
     }
 
     private fun requestScheduleExactAlarmsPermission() {
         Toast.makeText(this, R.string.toast_alarm_permission, Toast.LENGTH_LONG).show()
-        if (SDK_INT >= Build.VERSION_CODES.S) startActivityAndCollapseCompat(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+        if (SDK_INT >= Build.VERSION_CODES.S) startActivityAndCollapseCompat(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, Uri.parse("package:$packageName")))
     }
 
     private fun startActivityAndCollapseCompat(intent: Intent) {
         intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
-        intent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
         @SuppressLint("StartActivityAndCollapseDeprecated")
         if (SDK_INT <= TIRAMISU) @Suppress("DEPRECATION") startActivityAndCollapse(intent)
         else startActivityAndCollapse(getActivity(this, 0, intent, FLAG_IMMUTABLE))

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepTimer.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepTimer.kt
@@ -1,0 +1,10 @@
+package fr.smarquis.sleeptimer
+
+import android.os.Build
+
+object SleepTimer {
+    /**
+     * Android 17 introduced [Background audio hardening](https://developer.android.com/about/versions/17/changes/bg-audio) which prevents calling [android.media.AudioManager.adjustStreamVolume] from a background thread.
+     */
+    val REQUIRES_FOREGROUND_SERVICE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN
+}

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -8,7 +8,12 @@
 
     <!--region Notification-->
     <item name="notification_id" type="id" />
+    <item name="notification_service_id" type="id" />
     <string name="notification_channel_id">sleep_timer</string>
     <!--endregion-->
 
+    <!--region Toasts-->
+    <string name="toast_notification_permission"><i>Notifications</i> permission is required.</string>
+    <string name="toast_alarm_permission"><i>Alarms &amp; reminders</i> permission is required since <b>Android 17</b>.</string>
+    <!--endregion-->
 </resources>


### PR DESCRIPTION
A foreground service (with notification) is now required to change audio volume. Unfortunately, a notification `DeleteIntent` can not be linked to a Foreground Service `PendingIntent`... So, the good old `AlarmManager` had to be used, with a new permission `SCHEDULE_EXACT_ALARM`, that must be requested (and validated) at runtime...

Docs: https://developer.android.com/about/versions/17/changes/bg-audio