### PR TITLE
fix: recover tile state from STATE_UNAVAILABLE after upgrade or boot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:minSdkVersion="37" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" android:minSdkVersion="37" tools:ignore="ForegroundServicesPolicy" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="false"
@@ -38,6 +39,7 @@
             <!-- Refresh the tile state after an app update; the system resets active tiles to STATE_UNAVAILABLE. -->
             <intent-filter>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:minSdkVersion="37" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" android:minSdkVersion="37" tools:ignore="ForegroundServicesPolicy" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="false"
@@ -32,13 +31,7 @@
         <receiver
             android:name=".SleepActionReceiver"
             android:exported="true"
-            tools:ignore="ExportedReceiver">
-            <!-- Refresh the tile state after an app update; the system resets active tiles to STATE_UNAVAILABLE. -->
-            <intent-filter>
-                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
+            tools:ignore="ExportedReceiver" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,12 @@
         <receiver
             android:name=".SleepActionReceiver"
             android:exported="true"
-            tools:ignore="ExportedReceiver" />
+            tools:ignore="ExportedReceiver">
+            <!-- Refresh the tile state after an app update; the system resets active tiles to STATE_UNAVAILABLE. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,9 +25,6 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
             <meta-data
-                android:name="android.service.quicksettings.ACTIVE_TILE"
-                android:value="true" />
-            <meta-data
                 android:name="android.service.quicksettings.TOGGLEABLE_TILE"
                 android:value="true" />
         </service>

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepNotification.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepNotification.kt
@@ -29,22 +29,28 @@ object SleepNotification {
     fun Context.find() = notificationManager().activeNotifications?.firstOrNull { it.id == R.id.notification_id }?.notification
 
     /**
-     * @return a [Boolean] hint indicating the expected "visibility" state.
+     * @return the freshly posted [Notification] when starting, or `null` when cancelling.
      */
-    fun Context.toggle(): Boolean = if (find() == null) { show(); true } else { cancel(); false }
+    fun Context.toggle(): Notification? = if (find() == null) show() else {
+        cancel()
+        null
+    }
 
     fun Context.cancel() {
         notificationManager().cancel(R.id.notification_id)
         if (REQUIRES_FOREGROUND_SERVICE) alarmManager().cancel(SleepAudioService.pendingIntent(this))
     }
 
-    fun Context.update(delta: Long) = find()?.let { existing ->
+    fun Context.update(delta: Long): Notification? = find()?.let { existing ->
         val remaining = existing.`when` - currentTimeMillis()
         show(timeout = remaining + delta, existing)
     }
 
-    fun Context.show(timeout: Long = TIMEOUT_INITIAL_MILLIS, existing: Notification? = null) {
-        if (timeout <= 0) return cancel()
+    fun Context.show(timeout: Long = TIMEOUT_INITIAL_MILLIS, existing: Notification? = null): Notification? {
+        if (timeout <= 0) {
+            cancel()
+            return null
+        }
         val eta = currentTimeMillis() + timeout
         // Keep track of the original PendingIntent inside the notification's extras because
         // we can't rely on the Notification `deleteIntent` when `REQUIRES_FOREGROUND_SERVICE`
@@ -77,6 +83,7 @@ object SleepNotification {
             if (alarmManager().canScheduleExactAlarms().not()) Toast.makeText(this, R.string.toast_alarm_permission, Toast.LENGTH_LONG).show()
             else alarmManager().setExactAndAllowWhileIdle(RTC_WAKEUP, eta, sleepPendingIntent)
         }
+        return notification
     }
 
     private fun Context.createNotificationChannel() {

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
@@ -32,9 +32,6 @@ class SleepTileService : TileService() {
 
     override fun onStartListening() = refreshTile()
 
-    // Active tiles default to STATE_UNAVAILABLE on add; request a refresh so the tile is clickable.
-    override fun onTileAdded() = requestTileUpdate()
-
     override fun onClick() = when {
         notificationManager().areNotificationsEnabled().not() -> requestNotificationsPermission()
         REQUIRES_FOREGROUND_SERVICE && alarmManager().canScheduleExactAlarms().not() -> requestScheduleExactAlarmsPermission()

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
@@ -1,6 +1,7 @@
 package fr.smarquis.sleeptimer
 
 import android.annotation.SuppressLint
+import android.app.Notification
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.getActivity
 import android.content.ComponentName
@@ -38,22 +39,14 @@ class SleepTileService : TileService() {
         else -> toggle().let(::refreshTile)
     }
 
-    /**
-     * @param hint use `false` to force the [STATE_INACTIVE] update
-     */
-    private fun refreshTile(hint: Boolean? = null) = qsTile?.run {
-        val notification = find()
-        when {
-            // The canceled notification might still be considered active by NotificationManager... so we use an extra hint
-            notification == null || hint == false -> {
-                state = STATE_INACTIVE
-                if (SDK_INT >= Q) subtitle = resources.getText(R.string.tile_subtitle)
-            }
-
-            else -> {
-                state = STATE_ACTIVE
-                if (SDK_INT >= Q) subtitle = getTimeInstance(SHORT).format(Date(notification.`when`))
-            }
+    // Pass the just-posted/cancelled notification when available; activeNotifications doesn't reflect notify() synchronously.
+    private fun refreshTile(notification: Notification? = find()) = qsTile?.run {
+        if (notification == null) {
+            state = STATE_INACTIVE
+            if (SDK_INT >= Q) subtitle = resources.getText(R.string.tile_subtitle)
+        } else {
+            state = STATE_ACTIVE
+            if (SDK_INT >= Q) subtitle = getTimeInstance(SHORT).format(Date(notification.`when`))
         }
         updateTile()
     } ?: Unit

--- a/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
+++ b/app/src/main/java/fr/smarquis/sleeptimer/SleepTileService.kt
@@ -32,6 +32,9 @@ class SleepTileService : TileService() {
 
     override fun onStartListening() = refreshTile()
 
+    // Active tiles default to STATE_UNAVAILABLE on add; request a refresh so the tile is clickable.
+    override fun onTileAdded() = requestTileUpdate()
+
     override fun onClick() = when {
         notificationManager().areNotificationsEnabled().not() -> requestNotificationsPermission()
         REQUIRES_FOREGROUND_SERVICE && alarmManager().canScheduleExactAlarms().not() -> requestScheduleExactAlarmsPermission()


### PR DESCRIPTION
Fixes issues with the Sleep Tile becoming unavailable after app updates, app stops, and device reboots.

`ACTIVE_TILE` made SystemUI bind the tile only when we called `requestListeningState()`. If that chain ever broke (broadcast not delivered, bind fails, application stopped, etc.), the tile defaulted to `STATE_UNAVAILABLE`. By switching it to passive, SystemUI binds it every time the panel opens and `refreshTile` rewrites the state on every display. A separate race set `STATE_INACTIVE` after a tap because `notificationManager.notify()` the just-posted notification wasn't yet visible to `find()` — `show()`/`update()`/`toggle()` now return the posted `Notification` so `refreshTile` bypasses `find()` on state changes.

Confirmed that the tile survives both upgrades and reboots with these changes on my personal device using the apk built here: https://github.com/dambrisco/SleepTimer/actions/runs/25584393419

Fixes #179 